### PR TITLE
Add date parsing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Tests
+
+Ce dépôt contient un test minimal pour la fonction `parseFrDate`.
+
+## Exécution
+
+Assurez-vous d'avoir Node.js installé puis lancez simplement :
+
+```bash
+node tests/date.test.js
+```
+
+Si tout se passe bien, le message `Tous les tests passent.` apparaît.

--- a/tests/date.test.js
+++ b/tests/date.test.js
@@ -1,0 +1,26 @@
+const assert = require('assert');
+
+function parseFrDate(str) {
+  const [j, m, a] = str.split(/[\/\-]/);
+  return new Date(`${a}-${m}-${j}T00:00:00`);
+}
+
+function isValidDate(d) {
+  return d instanceof Date && !isNaN(d);
+}
+
+(function run() {
+  const d1 = parseFrDate('15/02/2024');
+  assert.ok(isValidDate(d1), 'date invalide pour 15/02/2024');
+  assert.strictEqual(d1.getFullYear(), 2024);
+  assert.strictEqual(d1.getMonth(), 1); // février => 1 (0-indexé)
+  assert.strictEqual(d1.getDate(), 15);
+
+  const d2 = parseFrDate('15-02-2024');
+  assert.ok(isValidDate(d2), 'date invalide pour 15-02-2024');
+  assert.strictEqual(d2.getFullYear(), 2024);
+  assert.strictEqual(d2.getMonth(), 1);
+  assert.strictEqual(d2.getDate(), 15);
+
+  console.log('Tous les tests passent.');
+})();


### PR DESCRIPTION
## Summary
- add a minimal README describing tests
- create tests/date.test.js using Node's assert module

## Testing
- `node tests/date.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68400fcf67f4832fab59ea14077a499e