### PR TITLE
Add light/dark theme switch

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,13 +39,35 @@ body{background:#1f2937;color:#e2e8f0}
 /* Animation fade-in */
 @keyframes fade-in { from { opacity: 0; transform: translateY(-10px);} to { opacity: 1; transform: none; } }
 .animate-fade-in { animation: fade-in 0.3s; transition: opacity 0.5s; }
+.light body{background:#ffffff;color:#1f2937}
+.light #sidebar{background:#f9fafb;border-color:#d1d5db;color:#1f2937}
+.light #sidebar .side-link{color:#374151}
+.light #sidebar .side-link.active{background:#e5e7eb;color:#111827}
+.light header{background:#ffffff;border-color:#d1d5db}
+.light .bg-gray-700{background-color:#f3f4f6!important;color:#1f2937!important}
+.light .bg-gray-800{background-color:#e5e7eb!important}
+.light .bg-gray-900{background-color:#f9fafb!important}
+.light .border-gray-600,.light .border-gray-700{border-color:#d1d5db!important}
+.light .text-gray-300{color:#374151!important}
+.light .text-gray-200{color:#4b5563!important}
+.light .text-gray-400{color:#6b7280!important}
+.light .text-white{color:#1f2937!important}
+.light .keep-white{color:#fff!important}
+#logo{transition:color .3s}
+.light #logo{color:#111827}
+#theme-toggle{transition:background-color .3s,color .3s}
+#theme-toggle:hover{background-color:#374151}
+.light #theme-toggle{color:#1f2937}
+.light #theme-toggle:hover{background-color:#e5e7eb}
+.theme-transition *{transition:background-color .3s,color .3s,border-color .3s}
+.handsontable.ht-theme-main .htCore{font-size:.8rem}
 </style>
 </head>
 <body class="flex h-full overflow-hidden">
 
 <!-- ===============  SIDEBAR  =============== -->
 <aside id="sidebar" class="flex flex-col items-center w-40 h-full text-gray-300 bg-gradient-to-b from-gray-800 via-gray-700 to-gray-800 border-r border-gray-600 rounded pt-6">
-<div class="text-lg font-semibold text-white mb-2 flex items-center gap-2">
+<div id="logo" class="text-lg font-semibold text-white mb-2 flex items-center gap-2">
   Rémus
 </div>
 <hr class="border-gray-600 mb-4 w-4/5 mx-auto opacity-40">  <div class="w-full px-2">
@@ -86,6 +108,7 @@ body{background:#1f2937;color:#e2e8f0}
 <div class="flex-1 flex flex-col overflow-hidden">
 <header class="h-16 px-8 flex items-center border-b border-gray-600">
   <h1 id="page-title" class="text-2xl font-bold text-rose-400">Accueil</h1>
+  <button id="theme-toggle" class="ml-auto px-2 py-1 rounded transition">🌙</button>
 </header>
 <main class="flex-1 overflow-auto">
 
@@ -99,25 +122,25 @@ body{background:#1f2937;color:#e2e8f0}
 
     <div class="grid grid-cols-1 md:grid-cols-3 gap-8 mt-4">
       <label class="group flex flex-col items-center justify-center h-44 rounded-xl bg-gradient-to-br from-emerald-600 to-emerald-400 hover:from-emerald-500 hover:to-emerald-300 cursor-pointer">
-        <span class="round-btn">M</span><span class="mt-4 font-medium text-white">Décisions JUB</span>
+        <span class="round-btn">M</span><span class="mt-4 font-medium text-white keep-white">Décisions JUB</span>
         <input id="file-main" type="file" accept=".xlsx,.xls,.csv" class="hidden">
       </label>
       <label class="group flex flex-col items-center justify-center h-44 rounded-xl bg-gradient-to-br from-amber-600 to-amber-400 hover:from-amber-500 hover:to-amber-300 cursor-pointer">
-        <span class="round-btn">R</span><span class="mt-4 font-medium text-white">Décisions retenues</span>
+        <span class="round-btn">R</span><span class="mt-4 font-medium text-white keep-white">Décisions retenues</span>
         <input id="file-retained" type="file" accept=".xlsx,.xls,.csv" class="hidden">
       </label>
       <label class="group flex flex-col items-center justify-center h-44 rounded-xl bg-gradient-to-br from-rose-600 to-rose-400 hover:from-rose-500 hover:to-rose-300 cursor-pointer">
-        <span class="round-btn">E</span><span class="mt-4 font-medium text-white">Décisions exclues</span>
+        <span class="round-btn">E</span><span class="mt-4 font-medium text-white keep-white">Décisions exclues</span>
         <input id="file-excluded" type="file" accept=".xlsx,.xls,.csv" class="hidden">
       </label>
     </div>
 
     <!-- Boutons sauvegarde / chargement -->
     <div class="flex flex-wrap items-center gap-4 mt-6">
-      <button id="btn-save-json" class="px-4 py-2 bg-cyan-500 hover:bg-cyan-600 text-white rounded">
+      <button id="btn-save-json" class="px-4 py-2 bg-cyan-500 hover:bg-cyan-600 text-white keep-white rounded">
         Sauvegarder dans le dossier
       </button>
-      <button id="btn-load-json" class="px-4 py-2 bg-indigo-500 hover:bg-indigo-600 text-white rounded">
+      <button id="btn-load-json" class="px-4 py-2 bg-indigo-500 hover:bg-indigo-600 text-white keep-white rounded">
         Charger sauvegarde JSON
       </button>
       <input type="file" id="json-file-input" accept=".json" class="hidden">
@@ -169,7 +192,7 @@ body{background:#1f2937;color:#e2e8f0}
   <div class="flex items-center gap-2">
     <input id="search-retained" placeholder="Rechercher…" class="px-2 py-1 rounded bg-gray-700 text-gray-200 w-60 focus:ring-emerald-400 focus:border-emerald-400">
     <span id="count-retained" class="text-sm text-gray-300"></span>
-    <button data-drawer-target="drawer-export" class="ml-auto px-4 py-1 bg-emerald-500 hover:bg-emerald-600 text-white rounded">Exporter .docx</button>
+      <button data-drawer-target="drawer-export" class="ml-auto px-4 py-1 bg-emerald-500 hover:bg-emerald-600 text-white keep-white rounded">Exporter .docx</button>
   </div>
   <div id="hot-retained" class="ht-theme-main-dark w-full" style="height:500px;z-index:0"></div>
   <div id="pager-retained" class="pager mt-2 flex items-center gap-4"></div>
@@ -241,7 +264,7 @@ body{background:#1f2937;color:#e2e8f0}
       <label for="form-id" class="block text-sm font-semibold text-amber-300 mb-1">Numéro</label>
       <input type="text" id="form-id" placeholder="App_12345/2025" class="w-full px-3 py-2 bg-gray-900 border-2 border-gray-700 focus:border-amber-400 text-amber-100 rounded-lg focus:ring-2 focus:ring-amber-400 transition placeholder:text-gray-400">
     </div>
-    <button type="submit" class="w-full flex items-center justify-center gap-2 px-4 py-3 bg-cyan-500 hover:bg-cyan-600 text-white rounded-lg text-lg font-semibold shadow transition">
+      <button type="submit" class="w-full flex items-center justify-center gap-2 px-4 py-3 bg-cyan-500 hover:bg-cyan-600 text-white keep-white rounded-lg text-lg font-semibold shadow transition">
       <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M7 10l5 5 5-5M12 4v12"/></svg>
       Lancer l'export
     </button>
@@ -253,6 +276,42 @@ body{background:#1f2937;color:#e2e8f0}
 
 <!-- =======================  SCRIPT GÉNÉRAL  ======================= -->
 <script>
+const themeBtn = document.getElementById('theme-toggle');
+function applyTheme(th){
+  const doc = document.documentElement;
+  doc.classList.add('theme-transition');
+  setTimeout(()=>doc.classList.remove('theme-transition'),300);
+  doc.classList.toggle('light', th==='light');
+  ['hot-main','hot-retained','hot-excluded'].forEach(id=>{
+    const el=document.getElementById(id);
+    if(!el) return;
+    el.classList.toggle('ht-theme-main', th==='light');
+    el.classList.toggle('ht-theme-main-dark', th!=='light');
+  });
+  const icon = th==='light' ? '🌙' : '☀️';
+  themeBtn.textContent = icon;
+  themeBtn.classList.toggle('text-white', th!=='light');
+  const c = th==='light' ? '#1f2937' : '#fff';
+  if(jurChart){
+    Chart.defaults.color = c;
+    [jurChart,lineChart].forEach(ch=>{
+      ch.options.plugins.legend.labels.color = c;
+    });
+    lineChart.options.scales.x.title.color = c;
+    lineChart.options.scales.x.ticks.color = c;
+    lineChart.options.scales.y.title.color = c;
+    lineChart.options.scales.y.ticks.color = c;
+    jurChart.update();
+    lineChart.update();
+  }
+  localStorage.setItem('theme', th);
+}
+themeBtn.addEventListener('click',()=>{
+  applyTheme(document.documentElement.classList.contains('light')?'dark':'light');
+});
+document.addEventListener('DOMContentLoaded',()=>{
+  applyTheme(localStorage.getItem('theme')||'dark');
+});
 /* ----------  Drawer  ---------- */
 const exportBtn = document.querySelector('[data-drawer-target="drawer-export"]');
 const closeBtn  = document.querySelector('[data-drawer-hide="drawer-export"]');
@@ -329,6 +388,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     }
   );
+  applyTheme(localStorage.getItem('theme')||'dark');
 });
 
 /* ----------  Stats & charts update  ---------- */
@@ -651,11 +711,11 @@ function paginate(hot, data, wrap, key) {
 
   // Couleurs par tableau
   const btnColors = {
-    main:     'bg-emerald-500 hover:bg-emerald-600 text-white',
-    retained: 'bg-amber-500 hover:bg-amber-600 text-white',
-    excluded: 'bg-rose-500 hover:bg-rose-600 text-white'
+    main:     'bg-emerald-500 hover:bg-emerald-600 text-white keep-white',
+    retained: 'bg-amber-500 hover:bg-amber-600 text-white keep-white',
+    excluded: 'bg-rose-500 hover:bg-rose-600 text-white keep-white'
   };
-  const colorClass = btnColors[key] || 'bg-gray-500 text-white';
+  const colorClass = btnColors[key] || 'bg-gray-500 text-white keep-white';
 
   // Bouton stylé
   const mkBtn = (t, cb, d) => {
@@ -861,8 +921,8 @@ document.getElementById('json-file-input').addEventListener('change', e=>{
 function showToast(message, type = "success") {
   const container = document.getElementById('toast-container');
   const colors = type === "success"
-    ? "bg-emerald-600 text-white"
-    : "bg-rose-600 text-white";
+    ? "bg-emerald-600 text-white keep-white"
+    : "bg-rose-600 text-white keep-white";
   const toast = document.createElement('div');
   toast.className = `px-4 py-2 rounded shadow ${colors} animate-fade-in`;
   toast.textContent = message;
@@ -1072,7 +1132,7 @@ document.addEventListener('DOMContentLoaded', () => {
       // Crée le bouton
       const btn = document.createElement('button');
       btn.textContent = label;
-      btn.className = `px-4 py-2 rounded ${btnColor} text-white shadow-lg`;
+      btn.className = `px-4 py-2 rounded ${btnColor} text-white keep-white shadow-lg`;
       btn.onclick = () => exportTableToExcel(key, `export_${key}_${new Date().toISOString().slice(0,10)}.xlsx`);
       exportDiv.innerHTML = '';
       exportDiv.appendChild(btn);


### PR DESCRIPTION
## Summary
- add theme toggle button
- include dark theme CSS and apply per theme
- update styles to support light theme
- toggle Handsontable theme per mode
- fix chart legend colors in light mode and ensure button text stays visible

## Testing
- `node tests/date.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68401a76d388832f86fa01b4e80c3d9a