### PR TITLE
Fix sidebar hover in light theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,8 @@ body{background:#1f2937;color:#e2e8f0}
 .light #sidebar{background:#f9fafb;border-color:#d1d5db;color:#1f2937}
 .light #sidebar .side-link{color:#374151}
 .light #sidebar .side-link.active{background:#e5e7eb;color:#111827}
+.light #sidebar .side-link:hover{background:#f3f4f6;color:#111827}
+.light #sidebar .side-link.active:hover{background:#e5e7eb}
 .light header{background:#ffffff;border-color:#d1d5db}
 .light .bg-gray-700{background-color:#f3f4f6!important;color:#1f2937!important}
 .light .bg-gray-800{background-color:#e5e7eb!important}


### PR DESCRIPTION
## Summary
- adjust CSS so sidebar links look correct when hovering in light mode

## Testing
- `node tests/date.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6840307f8710832fa230f9910e6c493a