### PR TITLE
Améliore style pagination

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@ body{background:#1f2937;color:#e2e8f0}
 .side-link.active::before{content:'';position:absolute;left:0;top:0;bottom:0;width:4px;background:#8b5cf6}
 .handsontable.ht-theme-main-dark .htCore{font-size:.8rem;color:#e2e8f0}
 .round-btn{@apply flex items-center justify-center w-16 h-16 rounded-full bg-emerald-500/30 group-hover:bg-emerald-500/50}
-.pager button{padding:.25rem .6rem;border:1px solid #475569;border-radius:.25rem}
+.pager button{padding:.25rem .6rem;border:none;border-radius:.25rem;box-shadow:0 1px 3px rgba(0,0,0,0.3)}
 .pager span{min-width:6rem;text-align:center;display:inline-block}
 .ht-search-result{background:#f59e0b40!important;color:#fde68a!important}
 
@@ -855,7 +855,7 @@ function paginate(hot, data, wrap, key, page = pageState[key] || 0) {
     const b = document.createElement('button');
     b.textContent = t;
     b.disabled = d;
-    b.className = `px-4 py-1 rounded ${colorClass} transition-colors duration-150`;
+    b.className = `px-4 py-2 rounded shadow-lg ${colorClass} transition-colors duration-150`;
     b.onclick = cb;
     return b;
   };


### PR DESCRIPTION
## Summary
- retire la bordure noire des boutons de pagination
- applique le même style que le bouton "Exporter Excel"

## Testing
- `node tests/date.test.js`
- `node tests/duplicates.test.js`
- `node tests/stats.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6840616ef3d4832fb02b732d86763ff4