### PR TITLE
Fix global search icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,16 +118,16 @@ body{background:#1f2937;color:#e2e8f0}
 <header class="h-16 px-8 flex items-center border-b border-gray-600">
   <h1 id="page-title" class="text-2xl font-bold text-rose-400">Accueil</h1>
   <button id="open-search" class="ml-6 flex items-center gap-2 text-gray-300 hover:text-white">
-    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M16.65 16.65A7.5 7.5 0 1016.65 2a7.5 7.5 0 000 14.65z" />
     </svg>
     <span class="hidden sm:inline">Recherche globale dans les tableaux</span>
     <kbd class="ml-2 text-xs text-gray-400">Ctrl K</kbd>
   </button>
-  <div id="search-overlay" class="hidden fixed inset-0 bg-black/50 backdrop-blur-sm flex items-start justify-center pt-20 z-50">
+  <div id="search-overlay" class="hidden fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50">
     <div class="bg-gray-800 rounded-lg w-96 p-4 shadow-lg">
       <div class="flex items-center gap-2">
-        <svg class="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M16.65 16.65A7.5 7.5 0 1016.65 2a7.5 7.5 0 000 14.65z" />
         </svg>
         <input id="global-search" type="text" placeholder="Recherche globale dans les tableaux" class="flex-1 bg-transparent outline-none text-white placeholder-gray-400" />


### PR DESCRIPTION
## Summary
- fix SVG for the global search button
- center the global search overlay

## Testing
- `node tests/date.test.js`
- `node tests/duplicates.test.js`
- `node tests/stats.test.js`


------
https://chatgpt.com/codex/tasks/task_e_684068ae94e8832fa13e06435e89efeb