### PR TITLE
Improve multi-term search

### DIFF
--- a/index.html
+++ b/index.html
@@ -776,8 +776,11 @@ function updateSelection(items){
 }
 
 function matchRow(row,q){
-  q = q.toLowerCase();
-  return Object.values(row).some(v=>String(v).toLowerCase().includes(q));
+  const terms = q.toLowerCase().split(/\s+/);
+  // all query words must appear in at least one cell
+  return terms.every(t =>
+    Object.values(row).some(v => String(v).toLowerCase().includes(t))
+  );
 }
 
 function navigateTo(tbl,idx){

--- a/tests/global-search.test.js
+++ b/tests/global-search.test.js
@@ -1,0 +1,16 @@
+const assert = require('assert');
+
+function matchRow(row, q) {
+  const terms = q.toLowerCase().split(/\s+/);
+  // all query words must appear in at least one cell
+  return terms.every(t =>
+    Object.values(row).some(v => String(v).toLowerCase().includes(t))
+  );
+}
+
+(function run(){
+  const row = { city: 'London', year: 2024 };
+  assert.ok(matchRow(row, 'London 2024'), 'should match across columns');
+  assert.ok(!matchRow(row, 'London 2023'), 'should fail if a term is missing');
+  console.log('Tous les tests matchRow passent.');
+})();


### PR DESCRIPTION
## Summary
- support searching multiple words by splitting the query in `matchRow`
- document the logic with a short comment
- test that multi-term queries match across columns

## Testing
- `node tests/date.test.js`
- `node tests/duplicates.test.js`
- `node tests/stats.test.js`
- `node tests/global-search.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6840708b434c832f9fb07af6976c1afa