### PR TITLE
Amélioration des résultats de la recherche globale

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@ body{background:#1f2937;color:#e2e8f0}
 .side-link.active::before{content:'';position:absolute;left:0;top:0;bottom:0;width:4px;background:#8b5cf6}
 .handsontable.ht-theme-main-dark .htCore{font-size:.8rem;color:#e2e8f0}
 .round-btn{@apply flex items-center justify-center w-16 h-16 rounded-full bg-emerald-500/30 group-hover:bg-emerald-500/50}
+.search-sub{@apply text-xs text-gray-400}
 .pager button{padding:.25rem .6rem;border:none;border-radius:.25rem;box-shadow:0 1px 3px rgba(0,0,0,0.3)}
 .pager span{min-width:6rem;text-align:center;display:inline-block}
 .ht-search-result{background:#f59e0b40!important;color:#fde68a!important}
@@ -806,7 +807,7 @@ gInput?.addEventListener('input',()=>{
     store[tbl].forEach((row,i)=>{
       if(matchRow(row,q)){
         const label = row["Numéro de l'affaire"] || row.Registry || row.Parties || `Ligne ${i+1}`;
-        res.push({tbl,idx:i,label});
+        res.push({tbl,idx:i,label,row});
       }
     });
   });
@@ -819,11 +820,22 @@ gInput?.addEventListener('input',()=>{
     return escapeHtml(str.slice(0,i))+`<mark>${escapeHtml(str.slice(i,i+q.length))}</mark>`+escapeHtml(str.slice(i+q.length));
   }
   res.slice(0,50).forEach(r=>{
-    const div=document.createElement('div');
-    div.className='px-2 py-1 cursor-pointer hover:bg-gray-600';
-    div.innerHTML=`[${r.tbl}] ${highlight(r.label,q)}`;
-    div.onclick=()=>{ navigateTo(r.tbl,r.idx); closeSearch(); };
-    gResults.appendChild(div);
+    const container=document.createElement('div');
+    container.className='px-2 py-1 cursor-pointer hover:bg-gray-600';
+    const labelDiv=document.createElement('div');
+    labelDiv.innerHTML=`[${r.tbl}] ${highlight(r.label,q)}`;
+    const infoDiv=document.createElement('div');
+    infoDiv.className='search-sub';
+    const infos=[
+      r.row.Dates || r.row.Date,
+      r.row.Juridiction || r.row.Court,
+      r.row.Parties
+    ].filter(Boolean).map(v=>highlight(String(v),q)).join(' • ');
+    infoDiv.innerHTML=infos;
+    container.appendChild(labelDiv);
+    if(infos) container.appendChild(infoDiv);
+    container.onclick=()=>{ navigateTo(r.tbl,r.idx); closeSearch(); };
+    gResults.appendChild(container);
   });
   selectedIndex = res.length?0:-1;
   updateSelection([...gResults.children]);


### PR DESCRIPTION
## Résumé
- ajout d'une classe `search-sub` pour l'affichage secondaire
- enrichissement des résultats de recherche avec un sous-bloc détaillant date, juridiction et parties

## Tests
- `node tests/date.test.js`
- `node tests/duplicates.test.js`
- `node tests/global-search.test.js`
- `node tests/stats.test.js`


------
https://chatgpt.com/codex/tasks/task_e_684073021d20832fb57f4d5311b6d171