### PR TITLE
Update global search display

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@ body{background:#1f2937;color:#e2e8f0}
 .side-link.active::before{content:'';position:absolute;left:0;top:0;bottom:0;width:4px;background:#8b5cf6}
 .handsontable.ht-theme-main-dark .htCore{font-size:.8rem;color:#e2e8f0}
 .round-btn{@apply flex items-center justify-center w-16 h-16 rounded-full bg-emerald-500/30 group-hover:bg-emerald-500/50}
-.search-sub{@apply text-xs text-gray-400}
+.search-sub{@apply block text-xs text-gray-400}
 .pager button{padding:.25rem .6rem;border:none;border-radius:.25rem;box-shadow:0 1px 3px rgba(0,0,0,0.3)}
 .pager span{min-width:6rem;text-align:center;display:inline-block}
 .ht-search-result{background:#f59e0b40!important;color:#fde68a!important}
@@ -835,18 +835,26 @@ gInput?.addEventListener('input',()=>{
   res.slice(0,50).forEach(r=>{
     const container=document.createElement('div');
     container.className='px-3 py-2 rounded-lg cursor-pointer hover:bg-gray-700';
+
+    const mainText  = highlight(r.row.Parties || r.label, q);
+    const subText   = [r.row["Numéro de l'affaire"] || r.row.Registry,
+                       r.row.Dates || r.row.Date,
+                       r.row.Juridiction || r.row.Court]
+                      .filter(Boolean)
+                      .map(v=>highlight(String(v),q))
+                      .join(' • ');
+
     const labelDiv=document.createElement('div');
-    labelDiv.innerHTML=`[${r.tbl}] ${highlight(r.label,q)}`;
-    const infoDiv=document.createElement('div');
-    infoDiv.className='search-sub';
-    const infos=[
-      r.row.Dates || r.row.Date,
-      r.row.Juridiction || r.row.Court,
-      r.row.Parties
-    ].filter(Boolean).map(v=>highlight(String(v),q)).join(' • ');
-    infoDiv.innerHTML=infos;
+    labelDiv.innerHTML=`[${r.tbl}] ${mainText}`;
     container.appendChild(labelDiv);
-    if(infos) container.appendChild(infoDiv);
+
+    if(subText){
+      const infoDiv=document.createElement('div');
+      infoDiv.className='search-sub';
+      infoDiv.innerHTML=subText;
+      container.appendChild(infoDiv);
+    }
+
     container.onclick=()=>{ navigateTo(r.tbl,r.idx); closeSearch(); };
     gResults.appendChild(container);
   });


### PR DESCRIPTION
## Summary
- show search results using parties as main text
- add subtext with case number, date, and court
- style subtext as small grey text

## Testing
- `node tests/date.test.js`
- `node tests/duplicates.test.js`
- `node tests/global-search.test.js`
- `node tests/stats.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6840b9264c28832fbb9c59a7781b2773