### PR TITLE
Ajout d’un filtre dans la recherche globale

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,6 +140,15 @@ mark{background:#facc15;color:inherit}
         <span><kbd>↑</kbd><kbd>↓</kbd> pour naviguer</span>
         <span><kbd>Esc</kbd> pour fermer</span>
       </div>
+      <div class="mt-2 flex items-center gap-2 text-sm">
+        <label for="search-filter" class="text-gray-400">Dans&nbsp;:</label>
+        <select id="search-filter" class="bg-gray-700 text-white rounded px-2 py-1 flex-1">
+          <option value="all">Tous les tableaux</option>
+          <option value="main">Toutes les décisions</option>
+          <option value="retained">Décisions retenues</option>
+          <option value="excluded">Décisions exclues</option>
+        </select>
+      </div>
       <div id="search-results" class="mt-2 max-h-60 overflow-auto divide-y divide-gray-700"></div>
     </div>
   </div>
@@ -743,7 +752,14 @@ const searchOverlay = document.getElementById('search-overlay');
 const closeSearchBtn = document.getElementById('close-search');
 const gInput   = document.getElementById('global-search');
 const gResults = document.getElementById('search-results');
+const gFilter  = document.getElementById('search-filter');
 let selectedIndex = -1;
+let activeSearchFilter = 'all';
+
+gFilter?.addEventListener('change', () => {
+  activeSearchFilter = gFilter.value;
+  gInput.dispatchEvent(new Event('input'));
+});
 
 function openSearch(){
   searchOverlay.classList.remove('hidden');
@@ -813,7 +829,10 @@ gInput?.addEventListener('input',()=>{
   gResults.innerHTML='';
   if(!q){ selectedIndex=-1; return; }
   const res=[];
-  ['main','retained','excluded'].forEach(tbl=>{
+  const tablesToSearch = activeSearchFilter === 'all'
+      ? ['main','retained','excluded']
+      : [activeSearchFilter];
+  tablesToSearch.forEach(tbl=>{
     store[tbl].forEach((row,i)=>{
       if(matchRow(row,q)){
         const label = row["Numéro de l'affaire"] || row.Registry || row.Parties || `Ligne ${i+1}`;


### PR DESCRIPTION
## Notes
- Ajout d’un sélecteur dans la fenêtre de recherche
- Suivi d’une variable `activeSearchFilter` pour filtrer les tableaux
- Mise à jour de l’événement de recherche en conséquence
- Tous les tests Node continuent de passer

------
https://chatgpt.com/codex/tasks/task_e_6840bb862c9c832f87df2706dc483161