### PR TITLE
Ajout d'un service worker pour le mode hors ligne

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,15 @@ Vous pouvez aussi exécuter l'ensemble des tests d'un coup :
 ```bash
 npm test
 ```
+
+## Fonctionnement hors ligne
+
+L'application utilise un *service worker* (`service-worker.js`) qui met en cache
+`index.html`, les bibliothèques JavaScript et le fichier `upc-data.json` lorsque
+il est disponible. Après avoir visité la page une première fois avec une
+connexion réseau, ces ressources restent accessibles et l'interface continue de
+fonctionner même hors ligne.
+
+Pour tester ce mode, ouvrez la page dans votre navigateur, puis activez l'option
+"Offline" dans les outils de développement (onglet Réseau). Rechargez ensuite
+la page : le contenu doit rester opérationnel grâce au cache.

--- a/index.html
+++ b/index.html
@@ -1549,6 +1549,14 @@ document.querySelectorAll('#export-form input, #export-form select').forEach(e =
 });
 updateExportSummary();
 </script>
+<script>
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", () => {
+    navigator.serviceWorker.register("./service-worker.js")
+      .catch(err => console.error("SW registration failed:", err));
+  });
+}
+</script>
 
 </body>
 </html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,40 @@
+const CACHE_NAME = 'jub-cache-v1';
+const ASSETS = [
+  './',
+  './index.html',
+  './service-worker.js',
+  './upc-data.json',
+  'https://cdn.tailwindcss.com',
+  'https://cdn.jsdelivr.net/npm/moment@2.29.4/moment.min.js',
+  'https://cdn.jsdelivr.net/npm/@handsontable/pikaday@1.0.0/pikaday.min.js',
+  'https://cdn.jsdelivr.net/npm/handsontable/dist/handsontable.full.min.js',
+  'https://cdn.jsdelivr.net/npm/handsontable@15.3.0/languages/fr-FR.js',
+  'https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js',
+  'https://cdn.jsdelivr.net/npm/chart.js'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k)))
+    )
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(cached => {
+      return cached || fetch(event.request).catch(() => {
+        if (event.request.mode === 'navigate') {
+          return caches.match('./index.html');
+        }
+      });
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- ajouter `service-worker.js` avec mise en cache des librairies et des données
- enregistrer le service worker dans `index.html`
- documenter le fonctionnement hors ligne dans le README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684172741cb8832f915bc5385cee1d71