### PR TITLE
Improve mark contrast for dark theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
   --highlight-bg:#f59e0b40;
   --highlight-text:#fde68a;
   --mark-bg:#facc15;
+  --mark-text-dark:#1f2937;
   --search-bg-dark:rgba(17,24,39,0.7);
   --kbd-bg-dark:#374151;
   --kbd-border-dark:#4b5563;
@@ -57,7 +58,8 @@ body{background:var(--bg-dark);color:var(--text-dark);font-family:'Inter','Helve
 .pager button{padding:.25rem .6rem;border:none;border-radius:.25rem;box-shadow:0 1px 3px rgba(0,0,0,0.3)}
 .pager span{min-width:6rem;text-align:center;display:inline-block}
 .ht-search-result{background:var(--highlight-bg)!important;color:var(--highlight-text)!important}
-mark{background:var(--mark-bg);color:inherit}
+mark{background:var(--mark-bg);color:var(--mark-text-dark)}
+.light mark{color:inherit}
 
 /* Global search styles */
 #search-overlay .search-box{backdrop-filter:blur(8px)}


### PR DESCRIPTION
## Summary
- introduce `--mark-text-dark` variable for highlight text in dark mode
- ensure `mark` text color uses new variable and falls back to inherited color in light mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842ba16cd48832f8fbb53cb2d233c8b