### PR TITLE
Fix docx export formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/Export JUB.html
+++ b/Export JUB.html
@@ -84,8 +84,14 @@ const ddmmyyyy = d => `${pad(d.getDate())}/${pad(d.getMonth()+1)}/${d.getFullYea
 function parseFrDate(str){
   if (typeof str !== 'string') return null;
   str = str.trim();
+  let m = str.match(/^(\d{4})-(\d{1,2})-(\d{1,2})/);
+  if(m){
+    const an=parseInt(m[1],10), mois=parseInt(m[2],10), j=parseInt(m[3],10);
+    const d=new Date(an, mois-1, j);
+    if(d.getFullYear()===an && d.getMonth()===mois-1 && d.getDate()===j) return d;
+  }
   const monthNames = { 'janvier':1,'février':2,'fevrier':2,'mars':3,'avril':4,'mai':5,'juin':6,'juillet':7,'août':8,'aout':8,'septembre':9,'octobre':10,'novembre':11,'décembre':12,'decembre':12 };
-  let m = str.match(/^(\d{1,2})[\/\-](\d{1,2})[\/\-](\d{2,4})$/);
+  m = str.match(/^(\d{1,2})[\/\-](\d{1,2})[\/\-](\d{2,4})$/);
   if(m){ let [ ,j,mois,an] = m.map(Number); if(an<100) an+=2000; const d=new Date(an,mois-1,j); if(d.getFullYear()===an&&d.getMonth()===mois-1&&d.getDate()===j) return d; return null; }
   m = str.match(/^(\d{1,2})\s+([\p{L}]+)/iu);
   if(m){ let j=parseInt(m[1],10); let reste=str.slice(m[0].length).trim(); const moisNom=m[2].toLowerCase(); const mois=monthNames[moisNom]; if(!mois) return null; m=reste.match(/^(\d{2,4})$/); if(!m) return null; let an=parseInt(m[1],10); if(an<100) an+=2000; const d=new Date(an,mois-1,j); if(d.getFullYear()===an&&d.getMonth()===mois-1&&d.getDate()===j) return d; }
@@ -173,9 +179,9 @@ function sanitizeApport(val){
   if(typeof val!== 'string') return val;
   let s=val.trim();
   s=s.replace(/\.\s+"}/g,'."}');
-  if(s&& !s.startsWith('{"')) s='{"'+s;
-  if(s&& !s.endsWith('"}')) s=s+'"}';
-  return s;
+  s=s.replace(/^\{\s*"?/, '');
+  s=s.replace(/["}]+$/, '');
+  return '{"'+s+'"}';
 }
 
 document.getElementById('export-form').addEventListener('submit',e=>{

--- a/index.html
+++ b/index.html
@@ -1312,6 +1312,18 @@ function parseFrDate(str) {
   if (typeof str !== 'string') return null;
   str = str.trim();
 
+  // Format ISO aaaa-mm-jj ou aaaa-mm-jjTHH:MM[:SS]
+  let m = str.match(/^(\d{4})-(\d{1,2})-(\d{1,2})/);
+  if (m) {
+    const an = parseInt(m[1], 10);
+    const mois = parseInt(m[2], 10);
+    const j = parseInt(m[3], 10);
+    const d = new Date(an, mois - 1, j);
+    if (d.getFullYear() === an && d.getMonth() === mois - 1 && d.getDate() === j) {
+      return d;
+    }
+  }
+
   const monthNames = {
     'janvier': 1, 'février': 2, 'fevrier': 2, 'mars': 3, 'avril': 4,
     'mai': 5, 'juin': 6, 'juillet': 7, 'août': 8, 'aout': 8,
@@ -1319,7 +1331,7 @@ function parseFrDate(str) {
   };
 
   // Formats numériques : JJ/MM/AAAA ou JJ-MM-AAAA (AA optionnel)
-  let m = str.match(/^(\d{1,2})[\/\-](\d{1,2})[\/\-](\d{2,4})$/);
+  m = str.match(/^(\d{1,2})[\/\-](\d{1,2})[\/\-](\d{2,4})$/);
   if (m) {
     let [ , j, mois, an ] = m.map(Number);
     if (an < 100) an += 2000;
@@ -1375,9 +1387,9 @@ function sanitizeApport(val){
   if(typeof val!== 'string') return val;
   let s = val.trim();
   s = s.replace(/\.\s+"}/g,'."}');
-  if(s && !s.startsWith('{"')) s = '{"' + s;
-  if(s && !s.endsWith('"}')) s = s + '"}';
-  return s;
+  s = s.replace(/^\{\s*"?/, '');
+  s = s.replace(/["}]+$/, '');
+  return '{"'+s+'"}';
 }
 
 document.getElementById('export-form').addEventListener('submit',e=>{

--- a/tests/date.test.js
+++ b/tests/date.test.js
@@ -5,13 +5,20 @@ function parseFrDate(str) {
   if (typeof str !== 'string') return null;
   str = str.trim();
 
+  let m = str.match(/^(\d{4})-(\d{1,2})-(\d{1,2})/);
+  if (m) {
+    const an = parseInt(m[1], 10), mois = parseInt(m[2], 10), j = parseInt(m[3], 10);
+    const d = new Date(an, mois - 1, j);
+    if (d.getFullYear() === an && d.getMonth() === mois - 1 && d.getDate() === j) return d;
+  }
+
   const monthNames = {
     'janvier': 1, 'février': 2, 'fevrier': 2, 'mars': 3, 'avril': 4,
     'mai': 5, 'juin': 6, 'juillet': 7, 'août': 8, 'aout': 8,
     'septembre': 9, 'octobre': 10, 'novembre': 11, 'décembre': 12, 'decembre': 12
   };
 
-  let m = str.match(/^(\d{1,2})[\/\-](\d{1,2})[\/\-](\d{2,4})$/);
+  m = str.match(/^(\d{1,2})[\/\-](\d{1,2})[\/\-](\d{2,4})$/);
   if (m) {
     let [ , j, mois, an ] = m.map(Number);
     if (an < 100) an += 2000;
@@ -90,5 +97,13 @@ describe('parseFrDate', function() {
     assert.strictEqual(d5.getFullYear(), 2024);
     assert.strictEqual(d5.getMonth(), 1);
     assert.strictEqual(d5.getDate(), 29);
+  });
+
+  it('parse iso format', function(){
+    const d6 = parseFrDate('2025-03-17T00:00:00Z');
+    assert.ok(isValidDate(d6));
+    assert.strictEqual(d6.getFullYear(), 2025);
+    assert.strictEqual(d6.getMonth(), 2);
+    assert.strictEqual(d6.getDate(), 17);
   });
 });


### PR DESCRIPTION
## Summary
- handle ISO date strings in `parseFrDate`
- sanitize brace formatting in docx export
- ignore local `node_modules`
- test ISO date parsing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a655ae1b8832fb0d28ed95f9fc805