### PR TITLE
Add apport validation tab

### DIFF
--- a/Export JUB.html
+++ b/Export JUB.html
@@ -25,9 +25,15 @@
     <p id="import-info" class="text-sm text-gray-400 mt-2"></p>
   </div>
 
-  <div class="bg-gray-700/70 rounded-lg p-4 shadow-lg">
-    <div id="export-summary" class="bg-amber-800/40 text-amber-100 rounded px-3 py-2 mb-4 text-sm font-medium shadow"></div>
-    <form id="export-form" class="space-y-4">
+  <div class="mt-6">
+    <div class="flex border-b border-gray-600 mb-4">
+      <button data-tab="export" class="tab-btn px-3 py-2 text-sm font-medium border-b-2 border-amber-400 text-amber-300">Export</button>
+      <button data-tab="check" class="tab-btn px-3 py-2 text-sm font-medium border-b-2 border-transparent text-gray-300 hover:text-white">Apports</button>
+    </div>
+    <div id="tab-export" class="tab-content">
+      <div class="bg-gray-700/70 rounded-lg p-4 shadow-lg">
+        <div id="export-summary" class="bg-amber-800/40 text-amber-100 rounded px-3 py-2 mb-4 text-sm font-medium shadow"></div>
+        <form id="export-form" class="space-y-4">
       <div>
         <label for="export-filename" class="block text-sm font-semibold text-amber-300 mb-1">Nom du fichier</label>
         <input type="text" id="export-filename" class="w-full px-3 py-2 bg-gray-900 border-2 border-gray-700 focus:border-amber-400 text-amber-100 rounded-lg focus:ring-2 focus:ring-amber-400 transition placeholder:text-gray-400" placeholder="Nom du fichier">
@@ -71,7 +77,15 @@
         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M7 10l5 5 5-5M12 4v12"/></svg>
         Lancer l'export
       </button>
-    </form>
+        </form>
+      </div>
+    </div>
+    <div id="tab-check" class="tab-content hidden">
+      <div class="bg-gray-700/70 rounded-lg p-4 shadow-lg">
+        <h2 class="text-lg font-semibold mb-2">Lignes avec apports mal formatés</h2>
+        <ul id="invalid-list" class="list-disc pl-5 text-sm space-y-1 text-red-200"></ul>
+      </div>
+    </div>
   </div>
 
   <div id="toast-container" class="fixed top-6 right-6 z-50 space-y-2"></div>
@@ -120,6 +134,7 @@ function parseFileRetained(file){
     document.getElementById('import-info').textContent = `Import réussi : ${arr.length} lignes`;
     populateExportLists();
     updateExportSummary();
+    updateApportWarnings();
   };
   fr.readAsArrayBuffer(file);
 }
@@ -162,6 +177,22 @@ function updateExportSummary(){
   document.getElementById('export-summary').textContent=txt;
 }
 
+function updateApportWarnings(){
+  const list=document.getElementById('invalid-list');
+  if(!list) return;
+  const warnings=[];
+  store.retained.forEach((r,i)=>{
+    [1,2,3].forEach(n=>{
+      const val=r[`Apport ${n}`];
+      if(!val) return;
+      const t=String(val).trim();
+      const invalid=!t.startsWith('{"')||!t.endsWith('"}')||/\s"}$/.test(t)||/\.\s+"}/.test(t);
+      if(invalid) warnings.push(`Ligne ${i+1}, Apport ${n}`);
+    });
+  });
+  list.innerHTML=warnings.length?warnings.map(w=>`<li>${w}</li>`).join(''):'<li>Aucune anomalie détectée</li>';
+}
+
 document.querySelectorAll('#export-form input, #export-form select').forEach(e=>{
   e.addEventListener('input', ()=>{
     document.getElementById('field-year').classList.toggle('hidden',document.getElementById('mode-year').checked===false);
@@ -170,19 +201,20 @@ document.querySelectorAll('#export-form input, #export-form select').forEach(e=>
     updateExportSummary();
   });
 });
+document.querySelectorAll('[data-tab]').forEach(btn=>{
+  btn.addEventListener('click',()=>{
+    document.querySelectorAll('[data-tab]').forEach(b=>b.classList.remove('border-amber-400','text-amber-300'));
+    document.querySelectorAll('.tab-content').forEach(c=>c.classList.add('hidden'));
+    btn.classList.add('border-amber-400','text-amber-300');
+    document.getElementById('tab-'+btn.dataset.tab).classList.remove('hidden');
+  });
+});
 updateExportSummary();
+updateApportWarnings();
 </script>
 
 <script type="module">
 import {Document,Packer,Paragraph,TextRun,AlignmentType,ShadingType} from 'https://cdn.jsdelivr.net/npm/docx@9.5.0/+esm';
-function sanitizeApport(val){
-  if(typeof val!== 'string') return val;
-  let s=val.trim();
-  s=s.replace(/\.\s+"}/g,'."}');
-  s=s.replace(/^\{\s*"?/, '');
-  s=s.replace(/["}]+$/, '');
-  return '{"'+s+'"}';
-}
 
 document.getElementById('export-form').addEventListener('submit',e=>{
   e.preventDefault();
@@ -214,7 +246,7 @@ document.getElementById('export-form').addEventListener('submit',e=>{
       const rule=r[`Règle/ Article ${n}`]||r[`Règle/Article  ${n}`]||'';
       const lt=r[`Legal Text ${n}`]||r[`Legal text ${n}`]||'';
       const subj=r[`Sujet ${n}`]||'';
-      const apport=sanitizeApport(r[`Apport ${n}`]||'');
+      const apport=r[`Apport ${n}`]||'';
       if(!rule&&!lt&&!subj&&!apport) return;
       if(rule) children.push(new Paragraph({alignment:AlignmentType.JUSTIFIED,children:[new TextRun({text:rule,bold:true,font:'Aptos',size:22,noProof:true})]}));
       if(lt) children.push(new Paragraph({alignment:AlignmentType.JUSTIFIED,children:[new TextRun({text:lt,bold:true,font:'Aptos',size:22,noProof:true})]}));


### PR DESCRIPTION
## Summary
- add tab navigation in Export JUB page
- show warnings for malformed `Apport` values
- remove automatic sanitization of apports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a68a36ca0832f8a574f3c631a7d1d