### PR TITLE
Ajout de messages pour les champs d'export vides

### DIFF
--- a/Export JUB.html
+++ b/Export JUB.html
@@ -163,15 +163,15 @@ function updateExportSummary(){
   if(mode==='year'){
     const y=parseInt(document.getElementById('form-year').value||0,10);
     if(y) rows=rows.filter(r=>{const d=parseFrDate(r.Dates)||new Date(r.Dates);return d.getFullYear()===y;});
-    txt=y?`Décisions pour l'année ${y} : ${rows.length}`:'';
+    txt=y?`Décisions pour l'année ${y} : ${rows.length}`:'Merci d\'indiquer une année !';
   } else if(mode==='month'){
     const [y,m]=(document.getElementById('form-month').value||'').split('-').map(Number);
     if(y&&m) rows=rows.filter(r=>{const d=parseFrDate(r.Dates)||new Date(r.Dates);return d.getFullYear()===y&&d.getMonth()+1===m;});
-    txt=(y&&m)?`Décisions pour ${m}/${y} : ${rows.length}`:'';
+    txt=(y&&m)?`Décisions pour ${m}/${y} : ${rows.length}`:'Merci d\'indiquer un mois !';
   } else if(mode==='id'){
     const id=document.getElementById('form-id').value.trim();
     rows=rows.filter(r=>{const a=String(r["Numéro de l'affaire"]).trim(),o=String(r["Numéro de l'ordonnance"]).trim();return a===id||o===id;});
-    txt=id?`Décisions pour le numéro ${id} : ${rows.length}`:'';
+    txt=id?`Décisions pour le numéro ${id} : ${rows.length}`:'Merci d\'indiquer un numéro d\'affaire !';
   } else {
     txt=`Décisions exportées : ${rows.length}`;
   }

--- a/index.html
+++ b/index.html
@@ -1576,7 +1576,7 @@ function updateExportSummary() {
         return d.getFullYear() === y;
       });
     }
-    txt = y ? `Décisions pour l'année ${y} : ${rows.length}` : '';
+    txt = y ? `Décisions pour l'année ${y} : ${rows.length}` : 'Merci d\'indiquer une année !';
   } else if (mode === 'month') {
     rows = [...store.retained];
     const [y, m] = (document.getElementById('form-month').value || '').split('-').map(Number);
@@ -1586,7 +1586,7 @@ function updateExportSummary() {
         return d.getFullYear() === y && d.getMonth() + 1 === m;
       });
     }
-    txt = (y && m) ? `Décisions pour ${m}/${y} : ${rows.length}` : '';
+    txt = (y && m) ? `Décisions pour ${m}/${y} : ${rows.length}` : 'Merci d\'indiquer un mois !';
   } else if (mode === 'id') {
     rows = [...store.retained];
     const id = document.getElementById('form-id').value.trim();
@@ -1594,7 +1594,7 @@ function updateExportSummary() {
       const a = String(r["Numéro de l'affaire"]).trim(), o = String(r["Numéro de l'ordonnance"]).trim();
       return a === id || o === id;
     });
-    txt = id ? `Décisions pour le numéro ${id} : ${rows.length}` : '';
+    txt = id ? `Décisions pour le numéro ${id} : ${rows.length}` : 'Merci d\'indiquer un numéro d\'affaire !';
   }
   document.getElementById('export-summary').textContent = txt;
 }


### PR DESCRIPTION
## Résumé
- complète la fonction `updateExportSummary` pour signaler les champs manquants
- met à jour le message affiché pour l'année, le mois ou le numéro

## Tests
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a6d2560f4832fab1c9b2d6d96572d