### PR TITLE
Add sanitizeFilename helper for docx exports

### DIFF
--- a/Export JUB.html
+++ b/Export JUB.html
@@ -93,6 +93,7 @@
 const store = { retained: [] };
 const pad = n => String(n).padStart(2,'0');
 const ddmmyyyy = d => `${pad(d.getDate())}/${pad(d.getMonth()+1)}/${d.getFullYear()}`;
+const sanitizeFilename = name => name.replace(/[\/\\:*?"<>|]/g,'');
 
 function parseFrDate(str){
   if (typeof str !== 'string') return null;
@@ -314,7 +315,7 @@ import {Document,Packer,Paragraph,TextRun,AlignmentType,ShadingType} from 'https
 
 document.getElementById('export-form').addEventListener('submit',e=>{
   e.preventDefault();
-  const filename=(document.getElementById('export-filename').value||'decisions_retenues')+'.docx';
+  const filename=sanitizeFilename(document.getElementById('export-filename').value||'decisions_retenues')+'.docx';
   let rows=[...store.retained];
   const mode=document.querySelector('#export-form input[name="mode"]:checked').value;
   if(mode==='year'){

--- a/index.html
+++ b/index.html
@@ -488,6 +488,7 @@ activateSideLink(document.querySelector('.side-link.active'));
 /* ----------  Utils  ---------- */
 const pad = n => String(n).padStart(2,'0');
 const ddmmyyyy = d => `${pad(d.getDate())}/${pad(d.getMonth()+1)}/${d.getFullYear()}`;
+const sanitizeFilename = name => name.replace(/[\/\\:*?"<>|]/g,'');
 
 /* ----------  Chart.js  ---------- */
 let jurChart, lineChart;
@@ -1390,7 +1391,7 @@ import {Document,Packer,Paragraph,TextRun,AlignmentType,ShadingType}
 
 document.getElementById('export-form').addEventListener('submit',e=>{
   e.preventDefault();
-  const filename=(document.getElementById('export-filename').value||'decisions_retenues')+'.docx';
+  const filename=sanitizeFilename(document.getElementById('export-filename').value||'decisions_retenues')+'.docx';
   let rows=[...store.retained];
   const mode=document.querySelector('#export-form input[name="mode"]:checked').value;
   if(mode==='year'){


### PR DESCRIPTION
## Summary
- add `sanitizeFilename()` utility
- sanitize export filename in module and standalone exporter

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aa463c4b4832f8e23e0ff86817864